### PR TITLE
fix: turkish-deasciifier source

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ import sys
 import subprocess
 import pkg_resources
 
-required = {'turkish-deasciifier', 'pyperclip','pynput'}
+required = {'git+https://github.com/emres/turkish-deasciifier.git', 'pyperclip','pynput'}
 installed = {pkg.key for pkg in pkg_resources.working_set}
 missing = required - installed
 


### PR DESCRIPTION
`setup.sh` doesn't install `turkish-deasciifier` since the library is not available on PyPi. The source is replaced with github URL.